### PR TITLE
Build native executables for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Runs a single command using the runners shell
       - name: Build for x86-64

--- a/README.md
+++ b/README.md
@@ -7,13 +7,20 @@ The build script does _not_ compile Ghidra. Instead, it downloads the binary
 release of Ghidra and the required Java JDK and packages them as a
 double-clickable Mac application.
 
-This works with both Intel x86-64 and Apple M1 Macs.
+This works with both Intel x86-64 and Apple arm64 Macs.
 
-This was heavily based on [Yifan Lu's](https://twitter.com/yifanlu) [Ghidra OSX Launch
-Script](https://gist.github.com/yifanlu/e9965cdb148b550335e57899f790cad2). The
-Ghidra icon file was taken directly from Lu's GitHub Gist.
+Currently, the claim about not compiling Ghidra is a partial lie. If you are
+building `Ghidra.app` for arm64, then the arm64 native executables Ghidra uses
+will be built by default. This is because the Ghidra distribution contains
+prebuilt binaries for x86-64 macOS, but not for arm64 macOS. The `-b` flag can
+be used to build native executables, regardless of the architecture.
+Similarly, the `-B` flag can be used to not build native executables (i.e.,
+use the prebuilt binaries instead).
 
-# Usage
+Hopefully, arm64 native executables will start being included and this script
+will return to simply assembling the macOS application wrapper.
+
+## Usage
 Clone the repository and run the `build.bash` script.
 ```
 $ git clone https://github.com/stevecheckoway/ghidra_app.git
@@ -23,22 +30,37 @@ $ ./build.bash
 
 At this point, you should have `Ghidra.app` in the `ghidra_app` directory.
 
-The script will download Ghidra (currently version 10.1.4 which is the most
-recent at time of writing, 2022-06-12) and OpenJDK 11. Together, these take
+The script will download Ghidra (currently version 10.3 which is the most
+recent at time of writing, 2023-06-02) and OpenJDK 17. Together, these take
 more than 450 MB.
 
 The downloads will be cached for future use in the `cache` directory. You may
 delete this directory after building if you wish.
 
-## Options
-There are a few options, they're likely not useful to anyone else.
+### Options
+There are a few options. You probably want the defaults.
 
 ```
 Usage: ./build.bash [OPTION...]
 
 Options:
-  -a arch include the JDK for x86-64 or arm64 [default: detect]
+  -a arch build Ghidra.app for x86-64 or arm64 [default: detect]
+  -b      build native executables [default for arm64]
+  -B      use prebuilt native executables [default for x86-64]
   -f      force building Ghidra.app even if it already exists
   -h      show this help
-  -o app  use 'app' as the output name
+  -o app  use 'app' as the output name instead of Ghidra.app
+
 ```
+
+## Credits
+
+This build script was heavily based on [Yifan
+Lu's](https://twitter.com/yifanlu) [Ghidra OSX Launch
+Script](https://gist.github.com/yifanlu/e9965cdb148b550335e57899f790cad2). The
+Ghidra icon file was taken directly from Lu's GitHub Gist.
+
+The approach for cross compiling the native executables came from [Robin
+Lambertz](https://github.com/roblabla/ghidra-ci). The `init.gradle` file is a
+modified version of their
+[`mac_arm_64.init.gradle`](https://github.com/roblabla/ghidra-ci/blob/7819b5feffdc27214cc133fdab64bb260c22a285/mac_arm_64.init.gradle) file.

--- a/init.gradle
+++ b/init.gradle
@@ -1,0 +1,16 @@
+allprojects {
+  model {
+    toolChains {
+      clang(Clang) {
+        target("mac_x86_64") {
+          cCompiler.withArguments { args -> args += ['-target', 'x86_64-apple-macos11' ] }
+          cppCompiler.withArguments { args -> args += ['-target', 'x86_64-apple-macos11' ] }
+        }
+        target("mac_arm_64") {
+          cCompiler.withArguments { args -> args += ['-target', 'arm64-apple-macos11' ] }
+          cppCompiler.withArguments { args -> args += ['-target', 'arm64-apple-macos11' ] }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ghidra doesn't include prebuilt native executables for arm64. Now we build them.