### PR TITLE
Updated for Ghidra 11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Options:
   -B      use prebuilt native executables [default for x86-64]
   -f      force building Ghidra.app even if it already exists
   -h      show this help
+  -n      use the latest Ghidra version
   -o app  use 'app' as the output name instead of Ghidra.app
 
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,12 @@
+/* ###
+ * IP: Public Domain
+ */
+// Recurse root project subdirectories and include all discovered projects 
+// (directories containing a build.gradle file) 
+fileTree(rootProject.projectDir) {
+	exclude 'build.gradle' // exclude root project
+	include '**/build.gradle'
+}.each {
+	include it.parentFile.name;
+	project(":$it.parentFile.name").projectDir = it.parentFile;
+}


### PR DESCRIPTION
The script was not working for the latest Ghidra so I made the following changes

- Updated JDK to 21.0.4 for x86_64 and arm
- Updated Ghidra URL
- New Ghidra doesn't have a `settings.gradle` file inside the Ghidra folder so I copied that file to Ghidra during build. Build fails without that file.
- Added a new flag `-n` to always build the latest Ghidra release. I also added the `clear_old_ghidra_versions` function to remove old versions.

